### PR TITLE
About import path

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -1,9 +1,9 @@
 package control
 
 import (
-	"nonograminGo/asset"
-	"nonograminGo/model"
-	"nonograminGo/util"
+	"github.com/N0RM4L15T/nonograminGo/asset"
+	"github.com/N0RM4L15T/nonograminGo/model"
+	"github.com/N0RM4L15T/nonograminGo/util"
 	"github.com/nsf/termbox-go"
 	"strconv"
 	"sync"

--- a/control/filemanager.go
+++ b/control/filemanager.go
@@ -1,8 +1,8 @@
 package control
 
 import (
-	"nonograminGo/asset"
-	"nonograminGo/util"
+	"github.com/N0RM4L15T/nonograminGo/asset"
+	"github.com/N0RM4L15T/nonograminGo/util"
 	"fmt"
 	"io/ioutil"
 	"math"

--- a/model/nonomap.go
+++ b/model/nonomap.go
@@ -1,8 +1,8 @@
 package model
 
 import (
-	"nonograminGo/asset"
-	"nonograminGo/util"
+	"github.com/N0RM4L15T/nonograminGo/asset"
+	"github.com/N0RM4L15T/nonograminGo/util"
 	"math"
 	"strconv"
 	"strings"

--- a/model/player.go
+++ b/model/player.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"nonograminGo/asset"
+	"github.com/N0RM4L15T/nonograminGo/asset"
 	"github.com/nsf/termbox-go"
 )
 

--- a/nonogram.go
+++ b/nonogram.go
@@ -1,6 +1,6 @@
 package main
 
-import "nonograminGo/control"
+import "github.com/N0RM4L15T/nonograminGo/control"
 
 func main() {
 

--- a/sometest.go
+++ b/sometest.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"nonograminGo/model"
+	"github.com/N0RM4L15T/nonograminGo/model"
 	"fmt"
 )
 


### PR DESCRIPTION
As go has been upgraded, previous import path(relative path) format doesn't work.
So change it to absolute path.